### PR TITLE
Windows Error Fix

### DIFF
--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -11,3 +11,4 @@ func _ready():
 	var filepath = OS.get_user_data_dir() + '/usersettings.tres'
 	if file.file_exists(filepath) == false:
 		file.open("user://usersettings.tres", File.WRITE)
+		file.close

--- a/scripts/windowsettings.gd
+++ b/scripts/windowsettings.gd
@@ -35,6 +35,7 @@ func fullscreen():
 func screensetting():
 	usersettings.open("user://usersettings.tres", File.READ_WRITE) # Open the usersettings file for reading and writing.
 	settings = usersettings.get_as_text() # Store the file as a string in settings variable.
+	usersettings.close() # Close user settings.
 	
 	# If no default screen size is set then set it to windowed.
 	if settings.find('screen:', 0) == -1:
@@ -53,5 +54,3 @@ func screensetting():
 	elif screen == 'f':
 		fullscreen()
 		return
-		
-	usersettings.close() # Close user settings.


### PR DESCRIPTION
Was getting errors when running on Windows. After hours of searching found it was all just because I hadn't closed an open text file in one script. Linux ran it just fine for some reason, but it understandably caused problems on Windows