### PR TITLE
small audio fixes

### DIFF
--- a/code/sound.gd
+++ b/code/sound.gd
@@ -34,7 +34,7 @@ func sfx(path, volume=0):
 	sfx.bus = 'SFX' # Set the bus to SFX.
 	sfx.name = audioname(path) # Make the node name the audio name.
 	sfx.volume_db = volume # Set the volume to volume.
-	sfx.connect('finished', self, 'stop_SFX', [sfx]) # Delete the node when finished.
+	#sfx.connect('finished', self, 'stop_SFX', [sfx]) # Delete the node when finished.
 	sfx.play() # Play the sound effect.
 	add_child(sfx) # Add as a child of sound.
 	

--- a/scripts/Davoo.tres
+++ b/scripts/Davoo.tres
@@ -767,6 +767,7 @@ No, brain, stop telling me what to think! I know how he looks.
 
 [fade to black]
 [Digi leaves]
+[StopMusic]
 [Location: dininghall.demo]
 [Song: PCPDating_Feed]
 [fade from black]
@@ -1281,7 +1282,7 @@ I meant every word I said
  
 [Scene: Was it Worth it?]
  
-[Location: pcpgroom]
+[Location: pcproom]
 [Song: PCPDating_HomeNight]
 [fade from black]
  

--- a/scripts/Digi.tres
+++ b/scripts/Digi.tres
@@ -183,7 +183,7 @@ I leave for home devastated and with a rotten feeling in the depths of my stomac
 [Scene: Corrupting Your Kids]
 
 [Location: outsidepcpu.night]
-[Song: PCPDating_SuspiciousFigga] 
+[Song: PCPDating_SuspiciousFigga]
 [fade from black]
  
 The bastion of academia looming above the city is easy to spot, despite the only source of light being an enormous, illuminated billboard on the other side of the street. 

--- a/scripts/Mage.tres
+++ b/scripts/Mage.tres
@@ -1,17 +1,19 @@
 [Scene: Shortcut]
 
-[Location: pcpgroom]
+[Location: pcproom]
 [Song: PCPDating_HomeNight]
 
 Woah, that was a long-ass day. Time to clean up and head to bed.
 
 [SFX: PCP-SFX_DoorOpen]
-[Location: pcpgbathroom]
+
+[Location: pcpbathroom]
 
 The classes in this school may be exhausting, but they are definitely way more interesting than all the other schools I attended.
 
 [StopMusic]
 [SFX: PCP-SFX_DoorOpen]
+
 [Location: hallway2.dream]
 [Song: PCPDating_Tension]
 
@@ -37,7 +39,7 @@ I’m... in the university? But it seems... different. Something is clearly wron
 (Mage|Mage, campus, 3, angryMIN) Anyways, we have to hurry! There is a horde of zombies following me, they will be here any moment!
 
 
-[Song: PCP-AMBIENT_Zombies]
+[SFX: PCP-AMBIENT_Zombies]
 
 (PCPG) There are zombies here?
 
@@ -54,21 +56,17 @@ Ok, this is most definitely not the real university. The professors all hate nat
 
 (Mage|Mage, campus, 3, happyMAX, center, slide, left) There she is!
 
-<<<<<<< HEAD
-(Cerise|???, cerise, happy, offright, slide, center) Mage! What a pleasure to meet you here! And who’s this? Your new boyfriend?
-=======
+
 (Cerise|???, happy, offright, slide, center) Mage! What a pleasure to meet you here! And who’s this? Your new boyfriend?
->>>>>>> 1fdf440c1b37676eaf1592c63b65ba2180811f72
+
 
 This conversation is somehow already more uncomfortable than getting chased by zombies.
 
 (Mage|Mage, campus, 1, angryMED|blushies) Quit joking Cerise, we have a problem! The zombies are back!
 
-<<<<<<< HEAD
-(cerise|Cerise, cerise, serious) Aww damn, and I thought we had completely annihilated them last night.
-=======
+
 (Cerise|Cerise, serious) Aww damn, and I thought we had completely annihilated them last night.
->>>>>>> 1fdf440c1b37676eaf1592c63b65ba2180811f72
+
 
 (Cerise) I will protect my Pokémon children!
 
@@ -79,7 +77,7 @@ This conversation is somehow already more uncomfortable than getting chased by z
 [SLIDE, Mage, left, offleft] 
 [SLIDE, Cerise, center, offright]
 
-[StopMusic]
+[StopSFX]
 [SFX: PCP-SFX_DemonScreetch]
 
 Wings grow out of the demon girl’s back, seeming to form giant claws, which start to slaughter the zombies as the horde enters from the hallways. Blood, organs and limbs fly through the air.
@@ -90,7 +88,7 @@ I feel nauseous.
 [Mage leaves]
 [cerise leaves]
 
-[Location: pcpgroom]
+[Location: pcproom]
 [StopMusic]
 
 AHHH!
@@ -103,7 +101,7 @@ This wacky university is like a world I never knew I wanted. A weird amalgam of 
 
 [fade to black]
 [StopMusic]
-[StopMusic]
+
 
 
 [Scene: Shadows of the Past]


### PR DESCRIPTION
changed how sound playback works to account for looping and nonlooping tracks. when you're using this version there's a specific way to set up in the UI. You need to reimport all non-looping SFX so that the loop feature is unchecked.
mage route has two music tracks try to play concurrently, changed one to sfx and modified sound properties
digi route has a missing track due to an extra space on the line, fixed it
davoo route had a missing music stop command. added this. this route has no crashes so that's cool